### PR TITLE
Fixed flaky tests in ASEConverterTest.java

### DIFF
--- a/src/main/java/sexpression/ASEConverter.java
+++ b/src/main/java/sexpression/ASEConverter.java
@@ -214,6 +214,7 @@ public class ASEConverter {
 
         /* Get the list of fields */
         Field[] fields = curClass.getDeclaredFields();
+        Arrays.sort(fields, Comparator.comparing(Field::getName));
 
         /* Concatenate those fields in the direct superclass */
         fields = Stream.concat(Arrays.stream(fields), Arrays.stream(curClass.getSuperclass().getDeclaredFields())).toArray(Field[]::new);

--- a/src/test/java/sexpression/test/ASEConverterTest.java
+++ b/src/test/java/sexpression/test/ASEConverterTest.java
@@ -9,6 +9,7 @@ import sexpression.StringWildcard;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import java.util.Map;
  */
 public class ASEConverterTest extends TestCase{
 
-    private Map<String,Integer> rsMap = new HashMap<>();
+    private Map<String,Integer> rsMap = new LinkedHashMap<>();
     private List<Map<String,Integer>> arrayMap = new ArrayList<>();
     private PlaintextRaceSelection p;
     private PlaintextRaceSelection pNew;
@@ -26,15 +27,15 @@ public class ASEConverterTest extends TestCase{
 
         int i = 2;
 
-        rsMap.put("Matt K", 0);
         rsMap.put("Matt B", 1);
+        rsMap.put("Matt K", 0);
         rsMap.put("Clayton", 0);
 
         p = new PlaintextRaceSelection(rsMap,"myRaceSelection",1);
         pNew = new PlaintextRaceSelection(null, "myNewRaceSelection",1);
 
         for (i = 0; i<3; i++) {
-            HashMap<String, Integer> newMap = new HashMap<String, Integer>();
+            HashMap<String, Integer> newMap = new LinkedHashMap<String, Integer>();
             newMap.putAll(rsMap);
             arrayMap.add(newMap);
         }
@@ -62,10 +63,10 @@ public class ASEConverterTest extends TestCase{
 
     public void testToASE(){
 
-        String expected = "(object java.util.HashMap (object sexpression.KeyValuePair (key java.lang.String Matt B) " +
-                          "(value java.lang.Integer 1)) (object sexpression.KeyValuePair (key java.lang.String Matt K) " +
-                          "(value java.lang.Integer 0)) (object sexpression.KeyValuePair (key java.lang.String Clayton) " +
-                          "(value java.lang.Integer 0)))";
+        String expected = "(object java.util.LinkedHashMap (object sexpression.KeyValuePair (key java.lang.String Matt B) " +
+                "(value java.lang.Integer 1)) (object sexpression.KeyValuePair (key java.lang.String Matt K) " +
+                "(value java.lang.Integer 0)) (object sexpression.KeyValuePair (key java.lang.String Clayton) " +
+                "(value java.lang.Integer 0)))";
 
 
         ListExpression rsExp = ASEConverter.convertToASE(rsMap);
@@ -82,7 +83,7 @@ public class ASEConverterTest extends TestCase{
         System.out.println("Expected: " + rsMap);
         System.out.println("Returned: " + rs + "\n");
 
-        expected = "(object crypto.PlaintextRaceSelection (voteMap java.util.HashMap (object sexpression.KeyValuePair " +
+        expected = "(object crypto.PlaintextRaceSelection (voteMap java.util.LinkedHashMap (object sexpression.KeyValuePair " +
                 "(key java.lang.String Matt B) (value java.lang.Integer 1)) (object sexpression.KeyValuePair " +
                 "(key java.lang.String Matt K) (value java.lang.Integer 0)) (object sexpression.KeyValuePair " +
                 "(key java.lang.String Clayton) (value java.lang.Integer 0))) (title java.lang.String myRaceSelection) " +
@@ -90,16 +91,21 @@ public class ASEConverterTest extends TestCase{
 
         ListExpression prs = ASEConverter.convertToASE(p);
 
-        assertEquals(expected, prs.toString());
+        String prsString = prs.toString();
+
+        assertTrue(prsString.contains("(object crypto.PlaintextRaceSelection (voteMap java.util.LinkedHashMap (object sexpression.KeyValuePair " +
+                "(key java.lang.String Matt B) (value java.lang.Integer 1)) (object sexpression.KeyValuePair " +
+                "(key java.lang.String Matt K) (value java.lang.Integer 0)) (object sexpression.KeyValuePair " +
+                "(key java.lang.String Clayton) (value java.lang.Integer 0)))") && prsString.contains("(title java.lang.String myRaceSelection)") && prsString.contains("(size java.lang.Integer 1)"));
 
         System.out.println("Expected: " + expected);
         System.out.println("Returned: " + prs + "\n");
 
-        expected = "(object java.util.HashMap (object sexpression.KeyValuePair (key NULL) (value java.lang.Integer 0)) " +
-                   "(object sexpression.KeyValuePair (key java.lang.String Dan) (value NULL)) " +
-                   "(object sexpression.KeyValuePair (key java.lang.String Matt B) (value java.lang.Integer 1)) " +
-                   "(object sexpression.KeyValuePair (key java.lang.String Matt K) (value java.lang.Integer 0)) " +
-                   "(object sexpression.KeyValuePair (key java.lang.String Clayton) (value java.lang.Integer 0)))";
+        expected = "(object java.util.LinkedHashMap (object sexpression.KeyValuePair (key NULL) (value java.lang.Integer 0)) " +
+                "(object sexpression.KeyValuePair (key java.lang.String Dan) (value NULL)) " +
+                "(object sexpression.KeyValuePair (key java.lang.String Matt B) (value java.lang.Integer 1)) " +
+                "(object sexpression.KeyValuePair (key java.lang.String Matt K) (value java.lang.Integer 0)) " +
+                "(object sexpression.KeyValuePair (key java.lang.String Clayton) (value java.lang.Integer 0)))";
 
         rsMap.put(null, 0);
         rsMap.put("Dan",null);
@@ -110,11 +116,13 @@ public class ASEConverterTest extends TestCase{
         System.out.println("Returned: " + rsExp + "\n");
 
         expected = "(object crypto.PlaintextRaceSelection (voteMap NULL) (title java.lang.String myNewRaceSelection) " +
-                   "(size java.lang.Integer 1))";
+                "(size java.lang.Integer 1))";
 
         prs = ASEConverter.convertToASE(pNew);
 
-        assertEquals(expected, prs.toString());
+        prsString = prs.toString();
+
+        assertTrue(prsString.contains("(object crypto.PlaintextRaceSelection (voteMap NULL)") && prsString.contains("(title java.lang.String myNewRaceSelection)") && prsString.contains("(size java.lang.Integer 1)"));
 
         System.out.println("Expected: " + expected);
         System.out.println("Returned: " + prs + "\n");
@@ -123,7 +131,7 @@ public class ASEConverterTest extends TestCase{
 
     public void testReciprocity(){
 
-        HashMap<String, Integer> newMap = new HashMap<String, Integer>();
+        HashMap<String, Integer> newMap = new LinkedHashMap<String, Integer>();
         newMap.putAll(rsMap);
 
         newMap.put(null, 0);

--- a/src/test/java/sexpression/test/ASEConverterTest.java
+++ b/src/test/java/sexpression/test/ASEConverterTest.java
@@ -64,9 +64,9 @@ public class ASEConverterTest extends TestCase{
     public void testToASE(){
 
         String expected = "(object java.util.LinkedHashMap (object sexpression.KeyValuePair (key java.lang.String Matt B) " +
-                "(value java.lang.Integer 1)) (object sexpression.KeyValuePair (key java.lang.String Matt K) " +
-                "(value java.lang.Integer 0)) (object sexpression.KeyValuePair (key java.lang.String Clayton) " +
-                "(value java.lang.Integer 0)))";
+                          "(value java.lang.Integer 1)) (object sexpression.KeyValuePair (key java.lang.String Matt K) " +
+                          "(value java.lang.Integer 0)) (object sexpression.KeyValuePair (key java.lang.String Clayton) " +
+                          "(value java.lang.Integer 0)))";
 
 
         ListExpression rsExp = ASEConverter.convertToASE(rsMap);
@@ -96,16 +96,18 @@ public class ASEConverterTest extends TestCase{
         assertTrue(prsString.contains("(object crypto.PlaintextRaceSelection (voteMap java.util.LinkedHashMap (object sexpression.KeyValuePair " +
                 "(key java.lang.String Matt B) (value java.lang.Integer 1)) (object sexpression.KeyValuePair " +
                 "(key java.lang.String Matt K) (value java.lang.Integer 0)) (object sexpression.KeyValuePair " +
-                "(key java.lang.String Clayton) (value java.lang.Integer 0)))") && prsString.contains("(title java.lang.String myRaceSelection)") && prsString.contains("(size java.lang.Integer 1)"));
+                "(key java.lang.String Clayton) (value java.lang.Integer 0)))") && 
+                prsString.contains("(title java.lang.String myRaceSelection)") && 
+                prsString.contains("(size java.lang.Integer 1)"));
 
         System.out.println("Expected: " + expected);
         System.out.println("Returned: " + prs + "\n");
 
         expected = "(object java.util.LinkedHashMap (object sexpression.KeyValuePair (key NULL) (value java.lang.Integer 0)) " +
-                "(object sexpression.KeyValuePair (key java.lang.String Dan) (value NULL)) " +
-                "(object sexpression.KeyValuePair (key java.lang.String Matt B) (value java.lang.Integer 1)) " +
-                "(object sexpression.KeyValuePair (key java.lang.String Matt K) (value java.lang.Integer 0)) " +
-                "(object sexpression.KeyValuePair (key java.lang.String Clayton) (value java.lang.Integer 0)))";
+                   "(object sexpression.KeyValuePair (key java.lang.String Dan) (value NULL)) " +
+                   "(object sexpression.KeyValuePair (key java.lang.String Matt B) (value java.lang.Integer 1)) " +
+                   "(object sexpression.KeyValuePair (key java.lang.String Matt K) (value java.lang.Integer 0)) " +
+                   "(object sexpression.KeyValuePair (key java.lang.String Clayton) (value java.lang.Integer 0)))";
 
         rsMap.put(null, 0);
         rsMap.put("Dan",null);
@@ -116,13 +118,15 @@ public class ASEConverterTest extends TestCase{
         System.out.println("Returned: " + rsExp + "\n");
 
         expected = "(object crypto.PlaintextRaceSelection (voteMap NULL) (title java.lang.String myNewRaceSelection) " +
-                "(size java.lang.Integer 1))";
+                   "(size java.lang.Integer 1))";
 
         prs = ASEConverter.convertToASE(pNew);
 
         prsString = prs.toString();
 
-        assertTrue(prsString.contains("(object crypto.PlaintextRaceSelection (voteMap NULL)") && prsString.contains("(title java.lang.String myNewRaceSelection)") && prsString.contains("(size java.lang.Integer 1)"));
+        assertTrue(prsString.contains("(object crypto.PlaintextRaceSelection (voteMap NULL)") && 
+                   prsString.contains("(title java.lang.String myNewRaceSelection)") && 
+                   prsString.contains("(size java.lang.Integer 1)"));
 
         System.out.println("Expected: " + expected);
         System.out.println("Returned: " + prs + "\n");


### PR DESCRIPTION
### Identified Flaky Tests in sexpression.test.ASEConverterTest.java

### List of Failing Tests:
**Class: sexpression.test.ASEConverterTest**
**Tests**
- [sexpression.test.ASEConverterTest#testReciprocity](https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/test/java/sexpression/test/ASEConverterTest.java#L124) 
- [sexpression.test.ASEConverterTest#testToASE](https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/test/java/sexpression/test/ASEConverterTest.java#L63)

### Reason for Test Failures:

The ASEConverterTest.java uses a HashMap for initializing rsMap as seen [here](https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/test/java/sexpression/test/ASEConverterTest.java#L20). 

https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/test/java/sexpression/test/ASEConverterTest.java#L20

As per the official [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), HashMap does not guarantee the order of element insertion, leading to the non-deterministic nature of these tests.
Implementing a LinkedHashMap instead of a HashMap addresses this issue as LinkedHashMap maintains insertion order, as stated in the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html).
An additional issue arises from the getDeclaredFields() method 

https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/main/java/sexpression/ASEConverter.java#L216

As per [documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), this method does not guarantee a consistent order of field return. A solution involves sorting the fields post-retrieval.
Similarly, [PlaintextRaceSelection](https://github.com/danwallach/star-vote-gradle/blob/e4a76205fcaf9a196485d467f2887df43fc04d13/src/test/java/sexpression/test/ASEConverterTest.java#L93) occasionally swaps {value, key} with {key, value}, which can be rectified by ensuring both key and value are present in the actual result.

### Solution Implemented:

Transitioned from HashMap to LinkedHashMap to ensure order preservation. After retrieving fields using getDeclaredFields(), they are now sorted. The issue with PlaintextRaceSelection was addressed by verifying the presence of both key and value in the actual result.

### Steps to Reproduce:
I utilized the open-source tool [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect this assumption by altering the order of returned exception types.

**To replicate:**

> Clone the Repository:
> ```
> git clone https://github.com/danwallach/star-vote-gradle.git
> ```

**Integrate NonDex:**

> Add the following snippet to the top of the build.gradle file:
> ```
> plugins {
>     id 'edu.illinois.nondex' version '2.1.1-1'
> }
> ```
> **Add the following to the end of the build.gradle file:**
> ```
> apply plugin: 'edu.illinois.nondex'
> ```

**Execute Test with Gradle:**

> ```
> ./gradlew --info test --tests sexpression.test.ASEConverterTest.testReciprocity
> ./gradlew --info test --tests sexpression.test.ASEConverterTest.testToASE
> ```

**Run NonDex:**
> ```
> ./gradlew --info nondexTest --tests=sexpression.test.ASEConverterTest.testReciprocity --nondexRuns=10
> ./gradlew --info nondexTest --tests=sexpression.test.ASEConverterTest.testToASE --nondexRuns=10
> ```

